### PR TITLE
Update egnn_pytorch_geometric.py

### DIFF
--- a/egnn_pytorch/egnn_pytorch_geometric.py
+++ b/egnn_pytorch/egnn_pytorch_geometric.py
@@ -224,8 +224,8 @@ class EGNN_Sparse(MessagePassing):
             **kwargs: Any additional data which is needed to construct and
                 aggregate messages, and to update node embeddings.
         """
-        size = self.__check_input__(edge_index, size)
-        coll_dict = self.__collect__(self.__user_args__,
+        size = self._check_input(edge_index, size)
+        coll_dict = self._collect(self._user_args,
                                      edge_index, size, kwargs)
         msg_kwargs = self.inspector.distribute('message', coll_dict)
         aggr_kwargs = self.inspector.distribute('aggregate', coll_dict)


### PR DESCRIPTION
This is due to a naming convention change in torch_geometric v2.3.0, where __attribute__ changed to _attribute. This means attributes like __check_input__ and __user_args__ have been renamed to _check_input and _user_args respectively. More details can be found in this pull request: pyg-team/pytorch_geometric#6999